### PR TITLE
ci(actions): add workflows for Docker image caching

### DIFF
--- a/.github/actions/docker-pull-retag-push/action.yaml
+++ b/.github/actions/docker-pull-retag-push/action.yaml
@@ -1,0 +1,41 @@
+name: docker-pull-retag-push
+description: |
+  Pulls a publicly available Docker image, retags it, and pushes it to a
+  target registry. Useful for caching upstream images on a schedule.
+
+inputs:
+  source:
+    required: true
+    description: "Source image reference to pull (e.g. ubuntu:24.04)."
+
+  destination:
+    required: true
+    description: "Destination image reference to push (e.g. ghcr.io/org/repo/ubuntu:24.04)."
+
+runs:
+  using: "composite"
+  steps:
+    - name: pull-retag-push
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        source="${{ inputs.source }}"
+        destination="${{ inputs.destination }}"
+
+        echo "::group::Pulling ${source}"
+        docker pull "${source}"
+        echo "::endgroup::"
+
+        echo "::group::Tagging as ${destination}"
+        docker tag "${source}" "${destination}"
+        echo "::endgroup::"
+
+        echo "::group::Pushing ${destination}"
+        docker push "${destination}"
+        echo "::endgroup::"
+
+        echo "### Cached image" >> "$GITHUB_STEP_SUMMARY"
+        echo "| Source | Destination |"  >> "$GITHUB_STEP_SUMMARY"
+        echo "| ------ | ----------- |"  >> "$GITHUB_STEP_SUMMARY"
+        echo "| \`${source}\` | \`${destination}\` |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-snapshot-monthly.yaml
+++ b/.github/workflows/docker-snapshot-monthly.yaml
@@ -1,0 +1,31 @@
+name: docker-snapshot-monthly
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # First day of every month at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source:
+          - ubuntu:rolling
+          - ubuntu:latest
+          - ubuntu:24.04
+          - ubuntu:22.04
+    steps:
+      - name: setup-login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: pull-retag-push
+        uses: ajakhotia/infraCommons/.github/actions/docker-pull-retag-push@main
+        with:
+          source: ${{ matrix.source }}
+          destination: ghcr.io/ajakhotia/infracommons/monthly/${{ matrix.source }}

--- a/.github/workflows/docker-snapshot-weekly.yaml
+++ b/.github/workflows/docker-snapshot-weekly.yaml
@@ -1,0 +1,31 @@
+name: docker-snapshot-weekly
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source:
+          - ubuntu:rolling
+          - ubuntu:latest
+          - ubuntu:24.04
+          - ubuntu:22.04
+    steps:
+      - name: setup-login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: pull-retag-push
+        uses: ajakhotia/infraCommons/.github/actions/docker-pull-retag-push@main
+        with:
+          source: ${{ matrix.source }}
+          destination: ghcr.io/ajakhotia/infracommons/weekly/${{ matrix.source }}


### PR DESCRIPTION
- Introduced `docker-pull-retag-push` composite action for retagging and pushing Docker images.
- Added `docker-snapshot-weekly` and `docker-snapshot-monthly` workflows for periodic Docker image caching.