### PR TITLE
ci(actions): add `matrix-aggregate` action for matrix job result validation

### DIFF
--- a/.github/actions/matrix-aggregate/action.yaml
+++ b/.github/actions/matrix-aggregate/action.yaml
@@ -1,0 +1,21 @@
+name: matrix-aggregate
+description: |
+  Checks the result of a matrix job and fails if any run did not succeed.
+  Use this in an aggregate job with `if: always()` and `needs: [matrix-job]`.
+
+inputs:
+  result:
+    required: true
+    description: "Result of the upstream job (pass needs.<job>.result)."
+
+runs:
+  using: "composite"
+  steps:
+    - name: check-result
+      shell: bash
+      run: |
+        echo "Result: ${{ inputs.result }}"
+        if [ "${{ inputs.result }}" != "success" ]; then
+          echo "One or more matrix runs failed."
+          exit 1
+        fi


### PR DESCRIPTION


- Introduced a composite action `matrix-aggregate` to validate matrix job results.
- Ensures aggregate job fails if any matrix job run is unsuccessful.