### PR TITLE
fix(cmake): use ACF_-prefixed variables in clang-format custom target

### DIFF
--- a/.github/workflows/test-cmake-find-package.yaml
+++ b/.github/workflows/test-cmake-find-package.yaml
@@ -1,10 +1,15 @@
 name: test-cmake-find-package
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/cmake-find-package/**'
-      - '.github/workflows/test-cmake-find-package.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-docker-pull-retag-push.yaml
+++ b/.github/workflows/test-docker-pull-retag-push.yaml
@@ -1,10 +1,15 @@
 name: test-docker-pull-retag-push
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/docker-pull-retag-push/**'
-      - '.github/workflows/test-docker-pull-retag-push.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-docker-typical-build-push.yaml
+++ b/.github/workflows/test-docker-typical-build-push.yaml
@@ -1,10 +1,15 @@
 name: test-docker-typical-build-push
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/docker-typical-build-push/**'
-      - '.github/workflows/test-docker-typical-build-push.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test-matrix-aggregate.yaml
+++ b/.github/workflows/test-matrix-aggregate.yaml
@@ -1,10 +1,15 @@
 name: test-matrix-aggregate
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/matrix-aggregate/**'
-      - '.github/workflows/test-matrix-aggregate.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-normalize.yaml
+++ b/.github/workflows/test-normalize.yaml
@@ -1,10 +1,15 @@
 name: test-normalize
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/normalize/**'
-      - '.github/workflows/test-normalize.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-oci-compliant-image-name.yaml
+++ b/.github/workflows/test-oci-compliant-image-name.yaml
@@ -1,11 +1,15 @@
 name: test-oci-compliant-image-name
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
-    paths:
-      - '.github/actions/oci-compliant-image-name/**'
-      - '.github/actions/normalize/**'
-      - '.github/workflows/test-oci-compliant-image-name.yaml'
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/cmake/utilities/clangFormat.cmake
+++ b/cmake/utilities/clangFormat.cmake
@@ -29,7 +29,7 @@ function(add_clang_format)
             -iname *.cpp -o -iname *.hpp -o
             -iname *.c -o -iname *.h -o
             -iname *.cc -o -iname *.hh
-          \\\) | ${XARGS} ${CLANG_FORMAT} -style=file -i
+          \\\) | ${ACF_XARGS} ${ACF_CLANG_FORMAT} -style=file -i
       WORKING_DIRECTORY
         ${PROJECT_SOURCE_DIR}
       COMMENT


### PR DESCRIPTION
The add_clang_format custom-target body referenced ${XARGS} and ${CLANG_FORMAT}, but find_program stores into ACF_XARGS / ACF_CLANG_FORMAT. The pipe collapsed to "... | -style=file -i", failing every format invocation.