### PR TITLE
Snapshot ubuntu:26.04 in the weekly and monthly workflows

### DIFF
--- a/.github/workflows/docker-snapshot-monthly.yaml
+++ b/.github/workflows/docker-snapshot-monthly.yaml
@@ -14,6 +14,7 @@ jobs:
         source:
           - ubuntu:rolling
           - ubuntu:latest
+          - ubuntu:26.04
           - ubuntu:24.04
           - ubuntu:22.04
     steps:

--- a/.github/workflows/docker-snapshot-weekly.yaml
+++ b/.github/workflows/docker-snapshot-weekly.yaml
@@ -14,6 +14,7 @@ jobs:
         source:
           - ubuntu:rolling
           - ubuntu:latest
+          - ubuntu:26.04
           - ubuntu:24.04
           - ubuntu:22.04
     steps:


### PR DESCRIPTION
Adds \`ubuntu:26.04\` to the weekly and monthly snapshot matrices so consumers can base images on \`ghcr.io/ajakhotia/infracommons/weekly/ubuntu:26.04\`. Needed by ajakhotia/robotFarm#57, which permutes CI over 22.04/24.04/26.04. After merging, dispatch the weekly workflow once to publish the tag immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AmWiRkHCcr52f3HNFkhw52