### PR TITLE
feat(docker, ci): publish weekly and monthly ubuntu base images with apt sources registered

### DIFF
--- a/.github/workflows/docker-base-image.yaml
+++ b/.github/workflows/docker-base-image.yaml
@@ -1,0 +1,201 @@
+name: docker-base-image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker-base-image.yaml'
+      - 'docker/ubuntuBase.dockerfile'
+      - 'tools/apt/addAptSources.sh'
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches:
+      - main
+    paths:
+      - '.github/workflows/docker-base-image.yaml'
+      - 'docker/ubuntuBase.dockerfile'
+      - 'tools/apt/addAptSources.sh'
+  schedule:
+    - cron: '0 0 * * 0' # Same tick as docker-snapshot-weekly; the wait job below sequences the two.
+    - cron: '0 0 1 * *' # Same tick as docker-snapshot-monthly; the wait job below sequences the two.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Each cadence shares its cron with the matching snapshot workflow and waits for that
+  # workflow's run on the same commit before building on top of the refreshed snapshots.
+  # For push, pull_request, and dispatch events no snapshot run exists for the commit, so the
+  # wait jobs pass through immediately and both cadences build. On a schedule tick only the
+  # cadence whose cron fired runs; the other cadence is skipped entirely.
+  wait-for-weekly-snapshot:
+    if: github.event_name != 'schedule' || github.event.schedule == '0 0 * * 0'
+    runs-on: ubuntu-latest
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: wait
+        id: wait
+        uses: ./.github/actions/wait-for-workflow
+        with:
+          workflow: docker-snapshot-weekly.yaml
+
+
+  weekly-base:
+    needs: wait-for-weekly-snapshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - ubuntu:26.04
+
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: setup-login
+        id: setup-login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup-buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: job-cache-base
+        id: job-cache-base
+        uses: ./.github/actions/oci-compliant-image-name
+        with:
+          build-name: job-cache/weekly-base/${{ matrix.os }}
+
+      - name: image-name-base
+        id: image-name-base
+        uses: ./.github/actions/oci-compliant-image-name
+        with:
+          build-name: weekly-base/${{ matrix.os }}
+
+      - name: base
+        id: base
+        uses: ./.github/actions/docker-typical-build-push
+        with:
+          dockerfile: docker/ubuntuBase.dockerfile
+          target-stage: base
+          cache-backend: registry
+          image-name: ${{ steps.image-name-base.outputs.name }}
+          shared-cache-to: ${{ steps.job-cache-base.outputs.name }}:cache
+          build-args: |
+            OS_BASE=ghcr.io/ajakhotia/infracommons/weekly/${{ matrix.os }}
+
+
+  aggregate-weekly-base:
+    name: aggregate-weekly-base
+    if: always() && (github.event_name != 'schedule' || github.event.schedule == '0 0 * * 0')
+    needs: [weekly-base]
+    runs-on: ubuntu-latest
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: aggregate
+        id: aggregate
+        uses: ./.github/actions/matrix-aggregate
+        with:
+          result: ${{ needs.weekly-base.result }}
+
+
+  wait-for-monthly-snapshot:
+    if: github.event_name != 'schedule' || github.event.schedule == '0 0 1 * *'
+    runs-on: ubuntu-latest
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: wait
+        id: wait
+        uses: ./.github/actions/wait-for-workflow
+        with:
+          workflow: docker-snapshot-monthly.yaml
+
+
+  monthly-base:
+    needs: wait-for-monthly-snapshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu:22.04
+          - ubuntu:24.04
+          - ubuntu:26.04
+
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: setup-login
+        id: setup-login
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: setup-buildx
+        id: setup-buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: job-cache-base
+        id: job-cache-base
+        uses: ./.github/actions/oci-compliant-image-name
+        with:
+          build-name: job-cache/monthly-base/${{ matrix.os }}
+
+      - name: image-name-base
+        id: image-name-base
+        uses: ./.github/actions/oci-compliant-image-name
+        with:
+          build-name: monthly-base/${{ matrix.os }}
+
+      - name: base
+        id: base
+        uses: ./.github/actions/docker-typical-build-push
+        with:
+          dockerfile: docker/ubuntuBase.dockerfile
+          target-stage: base
+          cache-backend: registry
+          image-name: ${{ steps.image-name-base.outputs.name }}
+          shared-cache-to: ${{ steps.job-cache-base.outputs.name }}:cache
+          build-args: |
+            OS_BASE=ghcr.io/ajakhotia/infracommons/monthly/${{ matrix.os }}
+
+
+  aggregate-monthly-base:
+    name: aggregate-monthly-base
+    if: always() && (github.event_name != 'schedule' || github.event.schedule == '0 0 1 * *')
+    needs: [monthly-base]
+    runs-on: ubuntu-latest
+    steps:
+      - name: self-checkout
+        id: self-checkout
+        uses: actions/checkout@v6
+
+      - name: aggregate
+        id: aggregate
+        uses: ./.github/actions/matrix-aggregate
+        with:
+          result: ${{ needs.monthly-base.result }}

--- a/README.md
+++ b/README.md
@@ -625,6 +625,34 @@ matrix.
 
 ---
 
+## 🐧 Published Ubuntu Base Images
+
+The snapshots above pin the upstream bits, and the base images go one step further. Built by
+[docker-base-image.yaml](.github/workflows/docker-base-image.yaml) from
+[docker/ubuntuBase.dockerfile](docker/ubuntuBase.dockerfile), each base image starts from the
+snapshot of its cadence, registers all of the vendor apt taps via
+[addAptSources.sh](tools/apt/addAptSources.sh) (gnu, llvm, nvidia, kitware), and runs a full
+upgrade after the taps are in place. The result is an Ubuntu image that already knows where the
+current toolchains live, while package selection stays entirely with consumers.
+
+```
+ghcr.io/ajakhotia/infracommons/<cadence>-base/<normalized-os>:<tag>
+```
+
+For example, the weekly base image for Ubuntu 24.04 is
+`ghcr.io/ajakhotia/infracommons/weekly-base/ubuntu-24-04:latest`. The OS segment is normalized
+for OCI compliance (`ubuntu:24.04` becomes `ubuntu-24-04`), and every push is also tagged
+`sha-<commit>`. Images are published for `ubuntu:22.04`, `ubuntu:24.04`, and `ubuntu:26.04` on
+both the `weekly` and the `monthly` cadence. Each cadence rebuilds right after the matching
+snapshot refresh, sequenced by the [wait-for-workflow](.github/actions/wait-for-workflow)
+action rather than by guessing at cron offsets.
+
+Downstream projects will eventually `FROM` these images directly instead of repeating the tap
+registration in their own Dockerfiles, which reduces their base stages to installing the
+packages they actually need.
+
+---
+
 ## 🔌 Using infraCommons in your project
 
 infraCommons is consumed as a **git submodule**. There is no package manager and no version

--- a/docker/ubuntuBase.dockerfile
+++ b/docker/ubuntuBase.dockerfile
@@ -1,0 +1,73 @@
+# syntax=docker/dockerfile:1.7
+ARG OS_BASE=ubuntu:24.04
+
+FROM ${OS_BASE} AS base
+
+ARG OS_BASE
+ENV OS_BASE=${OS_BASE}
+ENV APT_VAR_CACHE_ID=infracommons-apt-var-cache-${OS_BASE}
+ENV APT_LIST_CACHE_ID=infracommons-apt-list-cache-${OS_BASE}
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Trim documentation, manuals, and non-English locales at the dpkg level so every package
+# installed in this image and in its descendants stays lean.
+RUN printf '%s\n'                                                                                  \
+    'path-exclude /usr/share/doc/*'                                                                \
+    'path-exclude /usr/share/man/*'                                                                \
+    'path-include /usr/share/locale/locale.alias'                                                  \
+    'path-include /usr/share/locale/en*/*'                                                         \
+    'path-exclude /usr/share/locale/*'                                                             \
+    'path-exclude /usr/share/info/*'                                                               \
+    > /etc/dpkg/dpkg.cfg.d/01_nodoc
+
+# Work around hash-sum mismatches that intermediate proxies cause by disabling pipelining and
+# proxy caching for apt downloads.
+RUN printf '%s\n'                                                                                  \
+    'Acquire::http::Pipeline-Depth 0;'                                                             \
+    'Acquire::https::Pipeline-Depth 0;'                                                            \
+    'Acquire::http::No-Cache true;'                                                                \
+    'Acquire::https::No-Cache true;'                                                               \
+    'Acquire::BrokenProxy    true;'                                                                \
+    >> /etc/apt/apt.conf.d/90fix-hashsum-mismatch
+
+# Make apt resilient to flaky upstreams (e.g., Launchpad PPA hosting under stress):
+# 5 retries with short per-request timeouts so each failed attempt fails fast and
+# we get more shots at reaching a healthy backend behind the load balancer.
+RUN printf '%s\n'                                                                                  \
+    'Acquire::Retries "5";'                                                                        \
+    'Acquire::http::Timeout "30";'                                                                 \
+    'Acquire::https::Timeout "30";'                                                                \
+    > /etc/apt/apt.conf.d/91retry-and-timeouts
+
+RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                 \
+    --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked            \
+    apt-get update &&                                                                              \
+    apt-get full-upgrade -y --no-install-recommends &&                                             \
+    apt-get autoremove -y --no-install-recommends &&                                               \
+    apt-get autoclean -y --no-install-recommends
+
+# Install the minimum set of packages that addAptSources.sh itself requires. Package selection
+# stays with consumers, so nothing beyond that minimum is installed here.
+RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                 \
+    --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked            \
+    apt-get update &&                                                                              \
+    apt-get install -y --no-install-recommends                                                     \
+      ca-certificates curl gnupg software-properties-common
+
+# Register all vendor apt sources (gnu, llvm, nvidia, kitware). The build context is the
+# repository root, so the bind mount source resolves to this repository's own script.
+RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                 \
+    --mount=type=cache,target=/var/lib/apt/lists,id=${APT_LIST_CACHE_ID},sharing=locked            \
+    --mount=type=bind,src=tools/apt/addAptSources.sh,dst=/tmp/addAptSources.sh                     \
+    bash /tmp/addAptSources.sh -y
+
+# Refresh the package lists against the freshly registered sources and bake the resulting
+# upgrades into the image. The list cache mount is deliberately absent here: the lists are
+# written into the layer for the upgrade and then removed, so consumers inherit an upgraded
+# image with the vendor sources registered and no stale lists.
+RUN --mount=type=cache,target=/var/cache/apt,id=${APT_VAR_CACHE_ID},sharing=locked                 \
+    apt-get update &&                                                                              \
+    apt-get full-upgrade -y --no-install-recommends &&                                             \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## What

This PR adds a published Ubuntu base-image layer to infraCommons:

- `docker/ubuntuBase.dockerfile`: a single-stage image (stage `base`) that starts from a pinned snapshot, applies the standard apt hygiene (dpkg no-doc and locale trimming, the hashsum-mismatch workaround, retry and timeout tuning), installs only the packages that `addAptSources.sh` itself requires (`ca-certificates`, `curl`, `gnupg`, `software-properties-common`), registers all four vendor taps (gnu, llvm, nvidia, kitware), and finishes with a full upgrade against the registered sources. The final layer intentionally skips the apt-lists cache mount so the upgrade is baked into the image and the lists are removed afterwards, leaving consumers an upgraded image with no stale lists.
- `.github/workflows/docker-base-image.yaml`: builds and publishes the image for `ubuntu:22.04`, `ubuntu:24.04`, and `ubuntu:26.04` on both cadences as `ghcr.io/ajakhotia/infracommons/<cadence>-base/<os>` (OS segment normalized by `oci-compliant-image-name`, so for example `weekly-base/ubuntu-24-04:latest`).
- A README section documenting the published images next to the existing snapshot documentation.

## Why

Every downstream project currently repeats the same base-stage choreography: apt hygiene, tap registration, and an upgrade. Publishing that layer once lets downstream projects eventually `FROM` these images and reduce their own base stages to installing the packages they actually need. Package selection deliberately stays with consumers; this image only registers where the toolchains live.

## Scheduling design

The workflow shares its cron strings with the snapshot workflows (`0 0 * * 0` weekly, `0 0 1 * *` monthly) and sequences itself after them using this repo's own `wait-for-workflow` action, following the pattern established in niocRosBridge. Each cadence chain (wait, build matrix, aggregate gate) is guarded by `github.event.schedule`, so a weekly tick never rebuilds the monthly images and vice versa. On push, pull request, and dispatch events no snapshot run exists for the commit, so the wait jobs pass through immediately and both cadences build.

## Validation

- Full local build of the dockerfile for `OS_BASE=ubuntu:24.04` completed successfully, including tap registration and the final upgrade layer, which pulled upgraded packages from the freshly registered toolchain PPA.
- `docker buildx build --check` reports no warnings.
- The workflow YAML parses cleanly with PyYAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSXae9Ux4G6CVGmr57QAkZ