### PR TITLE
fix(cmake): forward a caller-chosen CMAKE_INSTALL_PREFIX explicitly

### DIFF
--- a/cmake/utilities/forwardedCacheArgs.cmake
+++ b/cmake/utilities/forwardedCacheArgs.cmake
@@ -149,5 +149,16 @@ function(compose_forwarded_cache_args)
     list(APPEND CFCA_RESULT "-DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_TOOLCHAIN_FILE}")
   endif()
 
+  # Newer CMake assigns CMAKE_INSTALL_PREFIX its own descriptive help string even when the value
+  # arrives via -D or a preset's cacheVariables, so the command-line marker misses it and the
+  # children would fall back to the platform default prefix. A caller-chosen prefix is
+  # distinguished from that default by CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT, so sweep it
+  # up explicitly.
+  if(CMAKE_INSTALL_PREFIX
+      AND NOT CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
+      AND NOT "CMAKE_INSTALL_PREFIX" IN_LIST CFCA_FORWARDED_NAMES)
+    list(APPEND CFCA_RESULT "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}")
+  endif()
+
   set(${CFCA_PARAM_OUTPUT_VARIABLE} "${CFCA_RESULT}" PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
robotFarm PR #57's find-package jobs all failed because every external project installed to /usr/local instead of /opt/robotFarm. Root cause: newer CMake (verified with upstream 4.4.2; the CI containers install the newest Kitware CMake) assigns CMAKE_INSTALL_PREFIX its own descriptive help string even when the value arrives via -D or a preset's cacheVariables, so both the capture and the compose-time sweep in forwardedCacheArgs.cmake miss it, and the children never receive the prefix.

The fix sweeps CMAKE_INSTALL_PREFIX explicitly, exactly like the existing CMAKE_TOOLCHAIN_FILE handling, guarded by CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT so a platform-default prefix is never forced onto children.

Verified locally against robotFarm's gnu-static preset: with CMake 4.4.2 the child configure args regain -DCMAKE_INSTALL_PREFIX:PATH=/opt/robotFarm, and with CMake 4.1.0 (where the marker still works) the forward appears exactly once, no duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSXae9Ux4G6CVGmr57QAkZ